### PR TITLE
Improve Vineflower decompilation

### DIFF
--- a/src/main/java/com/heliosdecompiler/transformerapi/decompilers/Decompiler.java
+++ b/src/main/java/com/heliosdecompiler/transformerapi/decompilers/Decompiler.java
@@ -88,7 +88,7 @@ public interface Decompiler<S> {
 
         @Override
         public String getName() {
-            return fullClassName;
+            return "TransformerAPI ClassStruct";
         }
 
         @Override

--- a/src/main/java/com/heliosdecompiler/transformerapi/decompilers/vineflower/VineflowerDecompiler.java
+++ b/src/main/java/com/heliosdecompiler/transformerapi/decompilers/vineflower/VineflowerDecompiler.java
@@ -27,6 +27,7 @@ import com.heliosdecompiler.transformerapi.common.Loader;
 import com.heliosdecompiler.transformerapi.decompilers.Decompiler;
 
 import java.io.IOException;
+import java.util.Map;
 
 import jd.core.DecompilationResult;
 
@@ -39,13 +40,10 @@ public class VineflowerDecompiler implements Decompiler<VineflowerSettings> {
     public DecompilationResult decompile(Loader loader, String internalName, VineflowerSettings settings) throws TransformationException, IOException {
         ClassStruct classStruct = readClassAndInnerClasses(loader, internalName);
         if (!classStruct.importantData().isEmpty()) {
-            IBytecodeProvider provider = new VineflowerBytecodeProvider(classStruct.importantData());
             VineflowerResultSaver saver = new VineflowerResultSaver();
-            Fernflower baseDecompiler = new Fernflower(provider, saver, settings.getSettings(), new PrintStreamLogger(System.out));
-            StructContext context;
+            Fernflower baseDecompiler = new Fernflower(saver, settings.getSettings(), new PrintStreamLogger(System.out));
+            baseDecompiler.addSource(classStruct);
             try {
-                context = DecompilerContext.getStructContext();
-                context.addSpace(classStruct, true);
                 baseDecompiler.decompileContext();
             } catch (Exception t) {
                 DecompilerContext.getLogger().writeMessage("Error while decompiling", t);

--- a/src/main/java/com/heliosdecompiler/transformerapi/decompilers/vineflower/VineflowerResultSaver.java
+++ b/src/main/java/com/heliosdecompiler/transformerapi/decompilers/vineflower/VineflowerResultSaver.java
@@ -16,6 +16,7 @@
 
 package com.heliosdecompiler.transformerapi.decompilers.vineflower;
 
+import jd.core.DecompilationResult;
 import org.vineflower.java.decompiler.main.extern.IResultSaver;
 
 import java.util.HashMap;
@@ -25,6 +26,12 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class VineflowerResultSaver implements IResultSaver {
+    private final DecompilationResult result;
+    private boolean lineNumbers;
+
+    public VineflowerResultSaver(DecompilationResult result) {
+        this.result = result;
+    }
 
     private static final String UNEXPECTED = "Unexpected";
 
@@ -32,6 +39,10 @@ public class VineflowerResultSaver implements IResultSaver {
 
     public Map<String, String> getResults() {
         return this.results;
+    }
+
+    public boolean hasLineRemapping() {
+        return lineNumbers;
     }
 
     public void saveClassEntry(String path, String archiveName, String qualifiedName, String entryName, String content) {
@@ -46,15 +57,12 @@ public class VineflowerResultSaver implements IResultSaver {
 
     public void saveClassFile(String path, String qualifiedName, String entryName, String content, int[] mapping) {
         if (mapping != null) {
-            String[] splits = content.split("\r?\n");
-
+            lineNumbers = true;
             for (int i = 0; i < mapping.length; i += 2) {
-                int srcLine = mapping[i + 1] - 1; // line in decompiled source
-                int actualLine = mapping[i]; // actual source line
-                splits[srcLine] = splits[srcLine] + " /* " + actualLine + " */";
+                int line = mapping[i + 1];
+                int actualLine = mapping[i];
+                result.putLineNumber(line, actualLine);
             }
-
-            content = Stream.of(splits).collect(Collectors.joining("\r\n"));
         }
         results.put(qualifiedName, content);
     }

--- a/src/main/java/com/heliosdecompiler/transformerapi/decompilers/vineflower/VineflowerSettings.java
+++ b/src/main/java/com/heliosdecompiler/transformerapi/decompilers/vineflower/VineflowerSettings.java
@@ -33,10 +33,19 @@ public class VineflowerSettings {
 
     public VineflowerSettings(Map<String, String> internalSettings) {
         this.internalSettings = new HashMap<>(internalSettings);
+        for (String key : internalSettings.keySet()) {
+            // Ignore options specified in legacy format.
+            // This both allows concurrent unique Fernflower and Vineflower options,
+            // and it fixes an issue where Fernflower options would override those of Vineflower's.
+            if (key.length() == 3) {
+                this.internalSettings.remove(key);
+            }
+        }
     }
 
     /**
-     * Set the given key to the given value. Keys can be found in {@link org.vineflower.java.decompiler.main.extern.IFernflowerPreferences}
+     * Set the given key to the given value. Built-in keys can be found in {@link org.vineflower.java.decompiler.main.extern.IFernflowerPreferences},
+     * and all options can be accessed with {@link org.vineflower.java.decompiler.api.DecompilerOption#getAll()}
      *
      * @return The same instance, for chaining
      */

--- a/src/main/java/com/heliosdecompiler/transformerapi/decompilers/vineflower/VineflowerTokenConsumer.java
+++ b/src/main/java/com/heliosdecompiler/transformerapi/decompilers/vineflower/VineflowerTokenConsumer.java
@@ -1,0 +1,90 @@
+package com.heliosdecompiler.transformerapi.decompilers.vineflower;
+
+import jd.core.DecompilationResult;
+import jd.core.links.DeclarationData;
+import jd.core.links.HyperlinkReferenceData;
+import jd.core.links.ReferenceData;
+import org.vineflower.java.decompiler.main.extern.TextTokenVisitor;
+import org.vineflower.java.decompiler.struct.gen.FieldDescriptor;
+import org.vineflower.java.decompiler.struct.gen.MethodDescriptor;
+import org.vineflower.java.decompiler.util.token.TextRange;
+
+public class VineflowerTokenConsumer extends TextTokenVisitor {
+    private final DecompilationResult result;
+    private String currentClass;
+
+    public VineflowerTokenConsumer(DecompilationResult result, TextTokenVisitor next) {
+        super(next);
+        this.result = result;
+    }
+
+    @Override
+    public void visitClass(TextRange range, boolean declaration, String name) {
+        if (declaration) {
+            currentClass = name;
+            DeclarationData data = new DeclarationData(range.start, range.length, name, null, null);
+            result.addDeclaration(toFragment(data, null), data);
+            result.addTypeDeclaration(range.start, data);
+        } else {
+            ReferenceData reference = new ReferenceData(name, null, null, currentClass);
+            addRef(range, reference);
+        }
+        super.visitClass(range, declaration, name);
+    }
+
+    @Override
+    public void visitField(TextRange range, boolean declaration, String className, String name, FieldDescriptor descriptor) {
+        if (declaration) {
+            DeclarationData data = new DeclarationData(range.start, range.length, className, name, descriptor.descriptorString);
+            result.addDeclaration(toFragment(data, descriptor.descriptorString), data);
+        } else {
+            ReferenceData reference = new ReferenceData(className, name, descriptor.descriptorString, currentClass);
+            addRef(range, reference);
+        }
+        super.visitField(range, declaration, className, name, descriptor);
+    }
+
+    @Override
+    public void visitMethod(TextRange range, boolean declaration, String className, String name, MethodDescriptor descriptor) {
+        if (declaration) {
+            DeclarationData data = new DeclarationData(range.start, range.length, className, name, descriptor.toString());
+            result.addDeclaration(toFragment(data, descriptor.toString()), data);
+        } else {
+            ReferenceData reference = new ReferenceData(className, name, descriptor.toString(), currentClass);
+            addRef(range, reference);
+        }
+        super.visitMethod(range, declaration, className, name, descriptor);
+    }
+
+    @Override
+    public void visitLocal(TextRange range, boolean declaration, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name) {
+        visitMethodBound(range, declaration, className, methodName, methodDescriptor, index, name, false);
+    }
+
+    @Override
+    public void visitParameter(TextRange range, boolean declaration, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name) {
+        visitMethodBound(range, declaration, className, methodName, methodDescriptor, index, name, true);
+    }
+
+    private void visitMethodBound(TextRange range, boolean declaration, String className, String methodName, MethodDescriptor methodDescriptor, int index, String name, boolean isParameter) {
+        String fakeDesc = methodDescriptor.toString() + '-' + (isParameter ? 'p' : 'l') + index;
+        if (declaration) {
+            DeclarationData data = new DeclarationData(range.start, range.length, className, methodName, fakeDesc);
+            result.addDeclaration(toFragment(data, fakeDesc), data);
+        } else {
+            ReferenceData reference = new ReferenceData(className, methodName, fakeDesc, currentClass);
+            addRef(range, reference);
+        }
+    }
+
+    private void addRef(TextRange range, ReferenceData reference) {
+        result.addReference(reference);
+        reference.setEnabled(true);
+        result.addHyperLink(range.start, new HyperlinkReferenceData(range.start, range.length, reference));
+    }
+
+    private static String toFragment(DeclarationData data, String desc) {
+        if (data.isAType()) return data.getTypeName();
+        return data.getTypeName() + '-' + data.getName() + '-' + desc;
+    }
+}


### PR DESCRIPTION
This modifies primarily the `VineflowerDecompiler` class to add functionality and improve operations:
- Properly interface with Vineflower instead of (rather hackily) manually adding a code source
- Mask out settings in Fernflower-style three-character form (allows the same options map to be passed to both while letting them be different)
- Use Vineflower text tokenization
  - Improves reference identifications over the existing AST-based parsing in jd-gui-duo
  - Supports local variables and parameters
  - Does not support packages or imports
- Improve generics handling and similar when URI is passed
- Move Vineflower's line numbers to the gutter