### PR TITLE
Update README dependencies and refine update workflow

### DIFF
--- a/.github/workflows/update-readme-version.yml
+++ b/.github/workflows/update-readme-version.yml
@@ -68,8 +68,8 @@ jobs:
               flags=re.DOTALL,
           )
           if replacements != 1:
-              print("::warning::Could not update README dependency snippet block; skipping README update.")
-              raise SystemExit(0)
+              print("::error::Could not update README dependency snippet block; expected exactly one marker block in README.md.")
+              raise SystemExit(1)
 
           readme_path.write_text(updated_readme)
           PY

--- a/.github/workflows/update-readme-version.yml
+++ b/.github/workflows/update-readme-version.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update-readme:
@@ -73,13 +74,15 @@ jobs:
           readme_path.write_text(updated_readme)
           PY
 
-      - name: Commit README update
-        run: |
-          if git diff --quiet -- README.md; then
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add README.md
-          git commit -m "Update README dependency version for ${{ github.ref_name }}"
-          git push origin "HEAD:${{ github.event.repository.default_branch }}"
+      - name: Create pull request for README update
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: README.md
+          base: ${{ github.event.repository.default_branch }}
+          branch: automation/update-readme-version-${{ github.run_id }}
+          delete-branch: true
+          commit-message: Update README dependency version for ${{ github.ref_name }}
+          title: Update README dependency version for ${{ github.ref_name }}
+          body: |
+            Automated README dependency snippet update for tag `${{ github.ref_name }}`.

--- a/.github/workflows/update-readme-version.yml
+++ b/.github/workflows/update-readme-version.yml
@@ -62,12 +62,13 @@ jobs:
 
           updated_readme, replacements = re.subn(
               r"<!-- dependency-snippets:start -->.*?<!-- dependency-snippets:end -->",
-              replacement,
+              lambda _match: replacement,
               readme,
               flags=re.DOTALL,
           )
           if replacements != 1:
-              raise SystemExit("Could not update README dependency snippet block.")
+              print("::warning::Could not update README dependency snippet block; skipping README update.")
+              raise SystemExit(0)
 
           readme_path.write_text(updated_readme)
           PY

--- a/.github/workflows/update-readme-version.yml
+++ b/.github/workflows/update-readme-version.yml
@@ -3,7 +3,7 @@ name: Update README version
 on:
   push:
     tags:
-      - "*"
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 permissions:
   contents: write
@@ -30,7 +30,7 @@ jobs:
           import re
           import textwrap
 
-          version = os.environ["RELEASE_VERSION"].removeprefix("v")
+          version = os.environ["RELEASE_VERSION"]
           readme_path = Path("README.md")
           readme = readme_path.read_text()
 

--- a/.github/workflows/update-readme-version.yml
+++ b/.github/workflows/update-readme-version.yml
@@ -1,0 +1,84 @@
+name: Update README version
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+
+jobs:
+  update-readme:
+    name: Update dependency snippets
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out default branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Update README dependency version
+        env:
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: |
+          python <<'PY'
+          from pathlib import Path
+          import os
+          import re
+          import textwrap
+
+          version = os.environ["RELEASE_VERSION"].removeprefix("v")
+          readme_path = Path("README.md")
+          readme = readme_path.read_text()
+
+          replacement = textwrap.dedent(
+              f"""\
+              <!-- dependency-snippets:start -->
+              ### Maven
+
+              ```xml
+              <dependency>
+                <groupId>io.github.nbauma109</groupId>
+                <artifactId>transformer-api</artifactId>
+                <version>{version}</version>
+              </dependency>
+              ```
+
+              ### Gradle
+
+              ```groovy
+              implementation 'io.github.nbauma109:transformer-api:{version}'
+              ```
+
+              ### Gradle Kotlin DSL
+
+              ```kotlin
+              implementation("io.github.nbauma109:transformer-api:{version}")
+              ```
+              <!-- dependency-snippets:end -->"""
+          )
+
+          updated_readme, replacements = re.subn(
+              r"<!-- dependency-snippets:start -->.*?<!-- dependency-snippets:end -->",
+              replacement,
+              readme,
+              flags=re.DOTALL,
+          )
+          if replacements != 1:
+              raise SystemExit("Could not update README dependency snippet block.")
+
+          readme_path.write_text(updated_readme)
+          PY
+
+      - name: Commit README update
+        run: |
+          if git diff --quiet -- README.md; then
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "Update README dependency version for ${{ github.ref_name }}"
+          git push origin "HEAD:${{ github.event.repository.default_branch }}"

--- a/.github/workflows/update-readme-version.yml
+++ b/.github/workflows/update-readme-version.yml
@@ -32,7 +32,7 @@ jobs:
 
           version = os.environ["RELEASE_VERSION"]
           readme_path = Path("README.md")
-          readme = readme_path.read_text()
+          readme = readme_path.read_text(encoding="utf-8")
 
           replacement = textwrap.dedent(
               f"""\
@@ -71,7 +71,7 @@ jobs:
               print("::error::Could not update README dependency snippet block; expected exactly one marker block in README.md.")
               raise SystemExit(1)
 
-          readme_path.write_text(updated_readme)
+          readme_path.write_text(updated_readme, encoding="utf-8")
           PY
 
       - name: Create pull request for README update

--- a/README.md
+++ b/README.md
@@ -18,20 +18,20 @@ API. The API is still subject to major changes, but only with a major version bu
 <dependency>
   <groupId>io.github.nbauma109</groupId>
   <artifactId>transformer-api</artifactId>
-  <version>4.2.6</version>
+  <version>4.2.5</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```groovy
-implementation 'io.github.nbauma109:transformer-api:4.2.6'
+implementation 'io.github.nbauma109:transformer-api:4.2.5'
 ```
 
 ### Gradle Kotlin DSL
 
 ```kotlin
-implementation("io.github.nbauma109:transformer-api:4.2.6")
+implementation("io.github.nbauma109:transformer-api:4.2.5")
 ```
 <!-- dependency-snippets:end -->
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,32 @@
 The Transformer API provides convenient access to different transformers (currently decompilers only) under a unified
 API. The API is still subject to major changes, but only with a major version bump.
 
+## Installation
+
+<!-- dependency-snippets:start -->
+### Maven
+
+```xml
+<dependency>
+  <groupId>io.github.nbauma109</groupId>
+  <artifactId>transformer-api</artifactId>
+  <version>4.2.6</version>
+</dependency>
+```
+
+### Gradle
+
+```groovy
+implementation 'io.github.nbauma109:transformer-api:4.2.6'
+```
+
+### Gradle Kotlin DSL
+
+```kotlin
+implementation("io.github.nbauma109:transformer-api:4.2.6")
+```
+<!-- dependency-snippets:end -->
+
 ## Usage
 
 Currently, this API supports the following decompilers :


### PR DESCRIPTION
This pull request introduces automation to keep the dependency version snippets in the `README.md` up to date whenever a new release tag is pushed. It adds a GitHub Actions workflow that updates the installation instructions for Maven and Gradle with the latest release version and creates a pull request with the changes. Additionally, the `README.md` now includes a clearly marked installation section with dependency snippets.

**Automation for dependency version updates:**

* Added a new GitHub Actions workflow (`.github/workflows/update-readme-version.yml`) that triggers on new release tags, updates the dependency version in the `README.md`, and creates a pull request with the changes.

**Documentation improvements:**

* Added an "Installation" section to the `README.md` with clearly marked dependency snippets for Maven, Gradle, and Gradle Kotlin DSL, including version markers for automated updates.