### PR TITLE
Update README dependencies and refine update workflow (#193)

### DIFF
--- a/.github/workflows/update-readme-version.yml
+++ b/.github/workflows/update-readme-version.yml
@@ -35,11 +35,17 @@ jobs:
               raise SystemExit(1)
 
           snapshot_version = version_element.text.strip()
-          if not snapshot_version.endswith("-SNAPSHOT"):
-              print(f"::error::Expected a -SNAPSHOT version in pom.xml, got '{snapshot_version}'.")
+          match = re.fullmatch(r"(\\d+)\\.(\\d+)\\.(\\d+)-SNAPSHOT", snapshot_version)
+          if not match:
+              print(f"::error::Expected semantic -SNAPSHOT version in pom.xml, got '{snapshot_version}'.")
               raise SystemExit(1)
 
-          version = snapshot_version[:-9]
+          major, minor, patch = map(int, match.groups())
+          if patch == 0:
+              print(f"::error::Cannot infer released version from '{snapshot_version}' because patch is 0.")
+              raise SystemExit(1)
+
+          version = f"{major}.{minor}.{patch - 1}"
           readme_path = Path("README.md")
           readme = readme_path.read_text(encoding="utf-8")
 

--- a/.github/workflows/update-readme-version.yml
+++ b/.github/workflows/update-readme-version.yml
@@ -19,33 +19,26 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
 
       - name: Update README dependency version
         run: |
           python <<'PY'
           from pathlib import Path
           import re
+          import subprocess
           import textwrap
-          import xml.etree.ElementTree as ET
 
-          pom_root = ET.parse("pom.xml").getroot()
-          version_element = pom_root.find("{http://maven.apache.org/POM/4.0.0}version")
-          if version_element is None or not version_element.text:
-              print("::error::Could not read project version from pom.xml.")
+          latest_tag = subprocess.run(
+              ["git", "describe", "--tags", "--abbrev=0"],
+              check=True,
+              capture_output=True,
+              text=True,
+          ).stdout.strip()
+          version = latest_tag.removeprefix("v")
+          if not re.fullmatch(r"\\d+\\.\\d+\\.\\d+", version):
+              print(f"::error::Expected a semantic version tag, got '{latest_tag}'.")
               raise SystemExit(1)
-
-          snapshot_version = version_element.text.strip()
-          match = re.fullmatch(r"(\\d+)\\.(\\d+)\\.(\\d+)-SNAPSHOT", snapshot_version)
-          if not match:
-              print(f"::error::Expected semantic -SNAPSHOT version in pom.xml, got '{snapshot_version}'.")
-              raise SystemExit(1)
-
-          major, minor, patch = map(int, match.groups())
-          if patch == 0:
-              print(f"::error::Cannot infer released version from '{snapshot_version}' because patch is 0.")
-              raise SystemExit(1)
-
-          version = f"{major}.{minor}.{patch - 1}"
           readme_path = Path("README.md")
           readme = readme_path.read_text(encoding="utf-8")
 

--- a/.github/workflows/update-readme-version.yml
+++ b/.github/workflows/update-readme-version.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.repository.default_branch }}
-          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Update README dependency version
         run: |

--- a/.github/workflows/update-readme-version.yml
+++ b/.github/workflows/update-readme-version.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
 
       - name: Update README dependency version
         env:

--- a/.github/workflows/update-readme-version.yml
+++ b/.github/workflows/update-readme-version.yml
@@ -34,7 +34,12 @@ jobs:
               print("::error::Could not read project version from pom.xml.")
               raise SystemExit(1)
 
-          version = version_element.text.strip()
+          snapshot_version = version_element.text.strip()
+          if not snapshot_version.endswith("-SNAPSHOT"):
+              print(f"::error::Expected a -SNAPSHOT version in pom.xml, got '{snapshot_version}'.")
+              raise SystemExit(1)
+
+          version = snapshot_version[:-9]
           readme_path = Path("README.md")
           readme = readme_path.read_text(encoding="utf-8")
 

--- a/.github/workflows/update-readme-version.yml
+++ b/.github/workflows/update-readme-version.yml
@@ -3,7 +3,7 @@ name: Update README version
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]*.[0-9]*.[0-9]*"
 
 permissions:
   contents: write

--- a/.github/workflows/update-readme-version.yml
+++ b/.github/workflows/update-readme-version.yml
@@ -1,0 +1,88 @@
+name: Update README version
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-readme:
+    name: Update dependency snippets
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out default branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Update README dependency version
+        env:
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: |
+          python <<'PY'
+          from pathlib import Path
+          import os
+          import re
+          import textwrap
+
+          version = os.environ["RELEASE_VERSION"]
+          readme_path = Path("README.md")
+          readme = readme_path.read_text(encoding="utf-8")
+
+          replacement = textwrap.dedent(
+              f"""\
+              <!-- dependency-snippets:start -->
+              ### Maven
+
+              ```xml
+              <dependency>
+                <groupId>io.github.nbauma109</groupId>
+                <artifactId>transformer-api</artifactId>
+                <version>{version}</version>
+              </dependency>
+              ```
+
+              ### Gradle
+
+              ```groovy
+              implementation 'io.github.nbauma109:transformer-api:{version}'
+              ```
+
+              ### Gradle Kotlin DSL
+
+              ```kotlin
+              implementation("io.github.nbauma109:transformer-api:{version}")
+              ```
+              <!-- dependency-snippets:end -->"""
+          )
+
+          updated_readme, replacements = re.subn(
+              r"<!-- dependency-snippets:start -->.*?<!-- dependency-snippets:end -->",
+              lambda _match: replacement,
+              readme,
+              flags=re.DOTALL,
+          )
+          if replacements != 1:
+              print("::error::Could not update README dependency snippet block; expected exactly one marker block in README.md.")
+              raise SystemExit(1)
+
+          readme_path.write_text(updated_readme, encoding="utf-8")
+          PY
+
+      - name: Create pull request for README update
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: README.md
+          base: ${{ github.event.repository.default_branch }}
+          branch: automation/update-readme-version-${{ github.run_id }}
+          delete-branch: true
+          commit-message: Update README dependency version for ${{ github.ref_name }}
+          title: Update README dependency version for ${{ github.ref_name }}
+          body: |
+            Automated README dependency snippet update for tag `${{ github.ref_name }}`.

--- a/.github/workflows/update-readme-version.yml
+++ b/.github/workflows/update-readme-version.yml
@@ -36,7 +36,7 @@ jobs:
               text=True,
           ).stdout.strip()
           version = latest_tag.removeprefix("v")
-          if not re.fullmatch(r"\\d+\\.\\d+\\.\\d+", version):
+          if not re.fullmatch(r"\d+\.\d+\.\d+", version):
               print(f"::error::Expected a semantic version tag, got '{latest_tag}'.")
               raise SystemExit(1)
           readme_path = Path("README.md")

--- a/.github/workflows/update-readme-version.yml
+++ b/.github/workflows/update-readme-version.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Create pull request for README update
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN }}
           add-paths: README.md
           base: ${{ github.event.repository.default_branch }}
           branch: automation/update-readme-version-${{ github.run_id }}

--- a/.github/workflows/update-readme-version.yml
+++ b/.github/workflows/update-readme-version.yml
@@ -2,36 +2,40 @@ name: Update README version
 
 on:
   push:
-    tags:
-      - "[0-9]*.[0-9]*.[0-9]*"
+    branches:
+      - master
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   update-readme:
     name: Update dependency snippets
     runs-on: ubuntu-latest
+    if: ${{ github.event.head_commit.message == '[maven-release-plugin] prepare for next development iteration' }}
 
     steps:
       - name: Check out default branch
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.repository.default_branch }}
-          persist-credentials: false
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Update README dependency version
-        env:
-          RELEASE_VERSION: ${{ github.ref_name }}
         run: |
           python <<'PY'
           from pathlib import Path
-          import os
           import re
           import textwrap
+          import xml.etree.ElementTree as ET
 
-          version = os.environ["RELEASE_VERSION"]
+          pom_root = ET.parse("pom.xml").getroot()
+          version_element = pom_root.find("{http://maven.apache.org/POM/4.0.0}version")
+          if version_element is None or not version_element.text:
+              print("::error::Could not read project version from pom.xml.")
+              raise SystemExit(1)
+
+          version = version_element.text.strip()
           readme_path = Path("README.md")
           readme = readme_path.read_text(encoding="utf-8")
 
@@ -75,15 +79,15 @@ jobs:
           readme_path.write_text(updated_readme, encoding="utf-8")
           PY
 
-      - name: Create pull request for README update
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.PAT_TOKEN }}
-          add-paths: README.md
-          base: ${{ github.event.repository.default_branch }}
-          branch: automation/update-readme-version-${{ github.run_id }}
-          delete-branch: true
-          commit-message: Update README dependency version for ${{ github.ref_name }}
-          title: Update README dependency version for ${{ github.ref_name }}
-          body: |
-            Automated README dependency snippet update for tag `${{ github.ref_name }}`.
+      - name: Commit and push README update
+        run: |
+          if git diff --quiet -- README.md; then
+            echo "No README changes detected."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "update version in readme"
+          git push origin "HEAD:${{ github.event.repository.default_branch }}"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,32 @@
 The Transformer API provides convenient access to different transformers (currently decompilers only) under a unified
 API. The API is still subject to major changes, but only with a major version bump.
 
+## Installation
+
+<!-- dependency-snippets:start -->
+### Maven
+
+```xml
+<dependency>
+  <groupId>io.github.nbauma109</groupId>
+  <artifactId>transformer-api</artifactId>
+  <version>4.2.5</version>
+</dependency>
+```
+
+### Gradle
+
+```groovy
+implementation 'io.github.nbauma109:transformer-api:4.2.5'
+```
+
+### Gradle Kotlin DSL
+
+```kotlin
+implementation("io.github.nbauma109:transformer-api:4.2.5")
+```
+<!-- dependency-snippets:end -->
+
 ## Usage
 
 Currently, this API supports the following decompilers :


### PR DESCRIPTION
This pull request introduces automation to keep the dependency version snippets in the `README.md` up to date after each release, reducing manual maintenance and potential errors. It does this by adding a GitHub Actions workflow that updates the version numbers in the README whenever a new release is prepared. Additionally, the README now includes a dedicated installation section with clear dependency instructions for Maven, Gradle, and Gradle Kotlin DSL.

Automation and workflow improvements:
* Added a new GitHub Actions workflow (`.github/workflows/update-readme-version.yml`) that runs on pushes to `master` with a specific commit message, automatically updating the dependency version snippets in the `README.md` to match the latest release tag and committing the change back to the repository.

Documentation improvements:
* Updated `README.md` to include a new Installation section with versioned dependency snippets for Maven, Gradle, and Gradle Kotlin DSL, enclosed in clearly marked comment blocks for automated updates.